### PR TITLE
fix Makefile.PL on newer perls without current directory in @INC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ inc/
 pm_to_blib
 *~
 blib
-
+/MYMETA.yml
+/MYMETA.json

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,3 +1,4 @@
+use lib '.';
 use inc::Module::Install;
 use Module::Install::Repository;
 use Module::Install::TestBase;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,6 @@
 use inc::Module::Install;
+use Module::Install::Repository;
+use Module::Install::TestBase;
 name 'Plack-Middleware-Header';
 all_from 'lib/Plack/Middleware/Header.pm';
 readme_from 'lib/Plack/Middleware/Header.pm';


### PR DESCRIPTION
Newer versions of perl don't include the current directory in `@INC`, but
Module::Install relies on that behavior.